### PR TITLE
Refactor URL handling: normalize, validate, and add service tests

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -44,6 +44,7 @@ dependencies {
 
 	// Tests
 	testImplementation("org.springframework.boot:spring-boot-starter-test")
+	testImplementation("org.mockito.kotlin:mockito-kotlin:5.2.1")
 	testImplementation("org.jetbrains.kotlin:kotlin-test-junit5")
 	testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 }

--- a/src/main/kotlin/com/codefactrory/shorty/domain/common/Base62Encoder.kt
+++ b/src/main/kotlin/com/codefactrory/shorty/domain/common/Base62Encoder.kt
@@ -1,0 +1,20 @@
+package com.codefactrory.shorty.domain.common
+
+object Base62Encoder {
+    private const val BASE62 = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
+
+    fun encode(number: Long, minLength: Int = 6): String {
+        var n = number
+        val sb = StringBuilder()
+        do {
+            sb.append(BASE62[(n % 62).toInt()])
+            n /= 62
+        } while (n > 0)
+
+        while (sb.length < minLength) {
+            sb.append('0')
+        }
+
+        return sb.reverse().toString()
+    }
+}

--- a/src/main/kotlin/com/codefactrory/shorty/domain/common/UrlNormalizer.kt
+++ b/src/main/kotlin/com/codefactrory/shorty/domain/common/UrlNormalizer.kt
@@ -1,0 +1,25 @@
+package com.codefactrory.shorty.domain.common
+
+import org.apache.commons.validator.routines.UrlValidator
+
+object UrlNormalizer {
+
+    private val urlValidator = UrlValidator(arrayOf("http", "https"))
+
+    fun normalizeAndValidate(url: String): String {
+        val normalized = url.trim()
+        val fullUrl = if (!normalized.startsWith("http://", ignoreCase = true) &&
+            !normalized.startsWith("https://", ignoreCase = true)
+        ) {
+            "https://$normalized"
+        } else {
+            normalized
+        }
+
+        if (!urlValidator.isValid(fullUrl)) {
+            throw IllegalArgumentException("Invalid URL: $fullUrl")
+        }
+
+        return fullUrl
+    }
+}

--- a/src/main/kotlin/com/codefactrory/shorty/domain/model/UrlMapping.kt
+++ b/src/main/kotlin/com/codefactrory/shorty/domain/model/UrlMapping.kt
@@ -5,7 +5,7 @@ import java.time.Instant
 
 @Entity
 @Table(name = "url")
-class UrlMapping (
+data class UrlMapping (
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/kotlin/com/codefactrory/shorty/infrastructure/adapter/incoming/UrlController.kt
+++ b/src/main/kotlin/com/codefactrory/shorty/infrastructure/adapter/incoming/UrlController.kt
@@ -29,7 +29,6 @@ class UrlController(
 
 data class UrlRequestDto(
     @field:NotBlank(message= "Url should not be blank")
-    @URL(message = "Invalid URL Format")
     val originalUrl: String
 )
 

--- a/src/test/kotlin/com/codefactrory/shorty/domain/UrlServiceTest.kt
+++ b/src/test/kotlin/com/codefactrory/shorty/domain/UrlServiceTest.kt
@@ -1,0 +1,89 @@
+package com.codefactrory.shorty.domain
+
+import com.codefactrory.shorty.domain.model.UrlMapping
+import com.codefactrory.shorty.domain.port.UrlRepositoryPort
+import com.codefactrory.shorty.domain.port.UrlRepositoryPortError
+import com.codefactrory.shorty.domain.port.UrlRepositoryPortError.UrlRepositoryPortNotFoundError
+import com.codefactrory.shorty.domain.service.UrlService
+import com.codefactrory.shorty.infrastructure.adapter.incoming.UrlRequestDto
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.*
+import org.mockito.kotlin.any
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.times
+
+class UrlServiceTest {
+
+    private val DEFAULT_ORIGINAL_URL = "https://www.dkbcodefactory.com/"
+    private lateinit var mockPort: UrlRepositoryPort
+    private lateinit var service: UrlService
+
+    @BeforeEach
+    fun setup() {
+        mockPort = mock(UrlRepositoryPort::class.java)
+        service = UrlService(
+            mockPort,
+            "http://localhost:8080",
+            6
+        )
+    }
+
+    @Test
+    fun `should return new short url when original not found`() {
+        val request = UrlRequestDto(DEFAULT_ORIGINAL_URL)
+
+        `when`(mockPort.findByOriginalUrl(DEFAULT_ORIGINAL_URL))
+            .thenThrow(UrlRepositoryPortNotFoundError("Not found by Original Url: $DEFAULT_ORIGINAL_URL"))
+
+        mockSaveBehavior()
+
+        val result = service.createShortUrl(request)
+
+        assertEquals(DEFAULT_ORIGINAL_URL, result.originalUrl)
+        assertTrue(result.shortUrl.startsWith("http://localhost:8080"))
+        verify(mockPort, times(2)).save(any())
+    }
+
+    @Test
+    fun `should return existing short url when original already exists`() {
+        val request = UrlRequestDto(DEFAULT_ORIGINAL_URL)
+        val existingMapping = UrlMapping(
+            id = 1L,
+            originalUrl = DEFAULT_ORIGINAL_URL,
+            shortUrlCode = "abc123"
+        )
+
+        `when`(mockPort.findByOriginalUrl(DEFAULT_ORIGINAL_URL))
+            .thenReturn(existingMapping)
+
+        val result = service.createShortUrl(request)
+
+        assertEquals(DEFAULT_ORIGINAL_URL, result.originalUrl)
+        assertEquals("http://localhost:8080/abc123", result.shortUrl)
+        verify(mockPort, never()).save(any()) // no save because already exists
+    }
+
+    @Test
+    fun `should propagate unexpected repository error`() {
+        val request = UrlRequestDto(DEFAULT_ORIGINAL_URL)
+
+        `when`(mockPort.findByOriginalUrl(DEFAULT_ORIGINAL_URL))
+            .thenThrow(UrlRepositoryPortError.UrlRepositoryPortUnexpectedError("DB failure"))
+
+        val ex = assertThrows(UrlRepositoryPortError.UrlRepositoryPortUnexpectedError::class.java) {
+            service.createShortUrl(request)
+        }
+
+        assertEquals("DB failure", ex.message)
+    }
+
+    private fun mockSaveBehavior() {
+        `when`(mockPort.save(any())).thenAnswer { invocation ->
+            val mapping = invocation.getArgument<UrlMapping>(0)
+            mapping.id = mapping.id ?: 1L
+            mapping
+        }
+    }
+}


### PR DESCRIPTION
**Description**:

- Removed @URL annotation from incoming DTO; URL validation and normalization are now handled in the service layer.
- Implemented consistent normalization and validation logic for saving and retrieving URLs.
- improved UrlService implementation.
- Added unit tests for UrlService
- Minor domain improvements: added Base62Encoder and UrlNormalizer utilities. and moved the implementation from service class